### PR TITLE
Potential bug fixes?

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Basic usage:
 * Run `./remy` to design a RemyCC (congestion-control algorithm) for
   the default scenario, with link speed drawn uniformly between 10 and
   20 Mbps, minRTT drawn uniformly between 100 and 200 ms, the maximum
-  degree of multiplexing drawn uniformly between 1 and 32, and each
+  degree of multiplexing drawn uniformly between 1 and 16, and each
   sender "on" for an exponentially-distributed amount of time (mean 5
   s) and off for durations drawn from the same distribution.
 

--- a/evaluator.cc
+++ b/evaluator.cc
@@ -24,7 +24,7 @@ Evaluator::Evaluator( const WhiskerTree & s_whiskers, const ConfigRange & range 
   _configs.push_back( NetConfig().set_link_ppt( range.link_packets_per_ms.second ).set_delay( range.rtt_ms.second ).set_num_senders( range.max_senders ) );
 
   /* now load some random ones just for fun */
-  for ( int i = 0; i < 12; i++ ) {
+  for ( int i = 0; i < 16; i++ ) {
     boost::random::uniform_real_distribution<> link_speed( range.link_packets_per_ms.first, range.link_packets_per_ms.second );
     boost::random::uniform_real_distribution<> rtt( range.rtt_ms.first, range.rtt_ms.second );
     boost::random::uniform_int_distribution<> num_senders( 1, range.max_senders );


### PR DESCRIPTION
1. Shouldn't README.md say that the max. multiplexing is 16 and not 32?
   (remy.cc uses 16 by default).
2. The SIGCOMM paper says that you run the innermost evaluation loop on
   16 candidate networks. Shouldn't the 12 in evaluator.cc be 16 then?
