### PR TITLE
Termination bug

### DIFF
--- a/src/network.cc
+++ b/src/network.cc
@@ -34,6 +34,7 @@ void Network<SenderType>::run_simulation( const double & duration )
 		   min( _delay.next_event_time( _tickno ),
 			_rec.next_event_time( _tickno ) ) );
 
+    if ( _tickno > duration ) break;
     assert( _tickno < std::numeric_limits<double>::max() );
 
     tick();


### PR DESCRIPTION
I am unsure if the assert is sensible because _tickno can legitimately be numeric_limits::max (because all 4 entities link, delay, sendergang and receiver can return numeric_limits::max). Besides, this check doesn't hurt anyone.
