### PR TITLE
Fixes to compile with stricter g++-4.9 checks

### DIFF
--- a/src/rat-templates.cc
+++ b/src/rat-templates.cc
@@ -7,7 +7,7 @@ using namespace std;
 
 template <class NextHop>
 void Rat::send( const unsigned int id, NextHop & next, const double & tickno,
-		const unsigned int packets_sent_cap )
+		const int packets_sent_cap )
 {
   assert( _packets_sent >= _largest_ack + 1 );
 

--- a/src/rat.hh
+++ b/src/rat.hh
@@ -35,7 +35,7 @@ public:
 
   template <class NextHop>
   void send( const unsigned int id, NextHop & next, const double & tickno,
-	     const unsigned int packets_sent_cap = std::numeric_limits<unsigned int>::max() );
+	     const int packets_sent_cap = std::numeric_limits<int>::max() );
 
   const WhiskerTree & whiskers( void ) const { return _whiskers; }
 

--- a/src/sendergang.hh
+++ b/src/sendergang.hh
@@ -48,6 +48,7 @@ private:
 	sending( false ),
 	id( s_id )
     {}
+    virtual ~SwitchedSender() {};
   };
 
   class TimeSwitchedSender : public SwitchedSender {


### PR DESCRIPTION
Not sure if these are 4.9 specific or apply to 4.8 as well (compiled on Ubuntu 14.10)
