### PR TITLE
Add plot scripts to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Makefile.in
 /protobufs/dna.pb.h
 /protobufs/problem.pb.cc
 /protobufs/problem.pb.h
+/protobufs/*_pb2.py
 /src/configuration
 /src/inspect-config
 /src/sender-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ addons:
     - libgtkmm-3.0-dev
     - libboost-dev
     - libglu1-mesa-dev
+    - python3-matplotlib
+    - python3-numpy
 
 before_script:
   - sudo -E add-apt-repository -y 'deb http://ftp.us.debian.org/debian unstable main contrib non-free'

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-graph --disable-silent-rules
 
-SUBDIRS = protobufs src tests
+SUBDIRS = protobufs src tests scripts
 
 if BUILD_GRAPH
 SUBDIRS += graph

--- a/configure.ac
+++ b/configure.ac
@@ -59,5 +59,5 @@ AC_LANG_POP(C++)
 
 # Checks for library functions.
 
-AC_CONFIG_FILES([Makefile protobufs/Makefile graph/Makefile src/Makefile tests/Makefile])
+AC_CONFIG_FILES([Makefile protobufs/Makefile graph/Makefile src/Makefile tests/Makefile scripts/Makefile])
 AC_OUTPUT

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,0 +1,3 @@
+dist_noinst_SCRIPTS = plot.py
+
+EXTRA_DIST = originals/linkspeed100x.plot originals/linkspeedcubic.plot originals/linkspeedcubicsfqCoDel.plot

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -326,12 +326,17 @@ def log_arguments(argsfile, args):
     jsondict = {
         "start-time": time.asctime(),
         "machine-name": gethostname(),
-        "git": {
-            "commit": subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip(),
-            "branch": subprocess.check_output(['git', 'symbolic-ref', '--short', '--quiet', 'HEAD']).decode().strip(),
-        },
-        "args": vars(args)
+        "args": vars(args),
+        "git": {},
     }
+    try:
+        jsondict["git"]["commit"] = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        jsondict["git"]["branch"] = subprocess.check_output(['git', 'symbolic-ref', '--short', '--quiet', 'HEAD']).decode().strip()
+    except subprocess.CalledProcessError:
+        pass
     json.dump(jsondict, argsfile, indent=2, sort_keys=True)
 
 def make_results_dir(dirname):

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,8 +1,8 @@
-dist_check_SCRIPTS = verify-2014-100x-results maintain-2013-results
+dist_check_SCRIPTS = verify-2014-100x-results maintain-2013-results run-plot-script.py
 
 EXTRA_DIST = RemyCC-2013-delta0.1.dna \
 	RemyCC-2013-delta10.dna \
 	RemyCC-2013-delta1.dna \
 	RemyCC-2014-100x.dna
 
-TESTS = verify-2014-100x-results maintain-2013-results
+TESTS = verify-2014-100x-results maintain-2013-results run-plot-script.py

--- a/tests/run-plot-script.py
+++ b/tests/run-plot-script.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+import subprocess
+import csv
+import os
+import shutil
+import unittest
+
+class TestPlotScript(unittest.TestCase):
+
+    RESULTS_DIR = "plot-results"
+    REMYCC_NAME = os.path.join(os.environ["srcdir"], "RemyCC-2014-100x.dna")
+    PLOT_SCRIPT = os.path.join(os.environ["srcdir"], "../scripts/plot.py")
+    ORIGINALS_DIR = os.path.join(os.environ["srcdir"], "../scripts/originals")
+    SENDERRUNNER = os.path.abspath("../src/sender-runner")
+
+    def test_scripts(self):
+
+        # Run as command line, not as Python import, to check command line interface
+        subprocess.check_output([self.PLOT_SCRIPT, self.REMYCC_NAME, "-n=10", "-r", self.RESULTS_DIR,
+                "--originals", self.ORIGINALS_DIR, "--sender-runner", self.SENDERRUNNER])
+
+        # Check data matches what was expected
+        EXPECTED_DATA = [
+            [0.1           , -3.652, 1.259, 15.58, 1.258, 16.08],
+            [0.215443469003, -1.098, 1.078, 2.305, 1.074, 2.307],
+            [0.464158883361, -0.493, 0.952, 1.339, 0.948, 1.337],
+            [1.0           , -0.444, 0.808, 1.097, 0.805, 1.099],
+            [2.15443469003 , -0.559, 0.876, 1.283, 0.865, 1.283],
+            [4.64158883361 , -0.586, 0.812, 1.219, 0.811, 1.218],
+            [10.0          , -0.533, 0.715, 1.038, 0.719, 1.038],
+            [21.5443469003 , -0.672, 0.640, 1.021, 0.640, 1.020],
+            [46.4158883361 , -1.119, 0.463, 1.000, 0.457, 1.000],
+            [100.0         , -2.233, 0.212, 1.000, 0.212, 1.000],
+        ]
+
+        result_file = open(os.path.join(self.RESULTS_DIR, "data", "data-" + os.path.basename(self.REMYCC_NAME) + ".csv"))
+        result_csv = csv.reader(result_file)
+
+        for expected_row, actual_row_str in zip(EXPECTED_DATA, result_csv):
+            actual_row = [float(x) for x in actual_row_str]
+
+            expected_link_ppt = expected_row.pop(0)
+            actual_link_ppt = actual_row.pop(0)
+            self.assertAlmostEqual(expected_link_ppt, actual_link_ppt)
+
+            expected_norm_score = expected_row.pop(0)
+            actual_norm_score = actual_row.pop(0)
+            self.assertAlmostEqual(expected_norm_score, actual_norm_score, delta=0.5)
+
+            for expected, actual in zip(expected_row, actual_row):
+                self.assertLess(abs((actual - expected)/expected), 0.2, msg="{} is not within 20% of {}".format(actual, expected))
+                self.assertEqual(actual > 0, expected > 0)
+
+        # clean up
+        os.unlink("last")
+        shutil.rmtree(self.RESULTS_DIR)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds the plotting script to what `make distcheck` does, and does some fixes to make sure it can run in the test environment.

I'm not really confident with Automake. Here's how I added it to `distcheck`:
* I added _scripts_ to `SUBDIRS` in the root directory.
* The makefile in _scripts_ has the _plot.py_ script in `dist_noinst_SCRIPTS`. My thinking was that this has to be distributed in order for the check to run, but it's not clear to me that it should be installed as part of the Remy package (at least not at this stage).
* I added the original data files (from the paper) to `EXTRA_DIST` in the _scripts_ directory. (I think this is where data for tests that is not installed goes?) The data itself isn't checked; they're there more to test that the "plot originals" part of the plotting script can run without error.
* I added a new test _run-plot-script.py_ to `dist_check_SCRIPTS` and `TESTS` in the _tests_ directory.
* The part I'm least sure about: In the dist tarball, _plot.py_ will be in its original source directory (because I told it to be), as will the original data files. But _sender-runner_, which is built, will be in the *_build* directory. This complicates paths. So _plot.py_ now takes an option where the location of _sender-runner_ can be specified explicitly. Now, _run-plot-script.py_ calls _plot.py_ using `os.environ["srcdir"]`, and it passes to it the location of where the built _sender-runner_ will be, which is `../src/sender-runner` (not in `os.environ["srcdir"]`). This works, but I wonder if these gymnastics indicate that I should make _plot.py_ part of the build or install. But if they do, I'm not sure how to do so appropriately.

Also, I found I needed to allow for a 20% difference when checking actual values against expected values. The _verify-2014-100x-results_ only allows for 5%. I'm not entirely sure why. It might be that I'm checking link speeds that tend to vary more, _e.g._ 0.1 as opposed to 2.21.