### PR TITLE
Ratatouille Improvement 

### DIFF
--- a/graph/fader.cc
+++ b/graph/fader.cc
@@ -71,16 +71,18 @@ GTKFader::GTKFader( const unsigned int & num_senders )
       window.add( stack );
 
       /* AIMD and RemyCC controls */
-      HBox senders;
-      stack.pack_start( senders, PACK_SHRINK );
-
       deque<LabeledToggle> sender_controls;
+
+      HBox aimd_senders;
+      stack.pack_start( aimd_senders, PACK_SHRINK );
       for ( unsigned int i = 0; i < num_senders; i++ ) {
-	sender_controls.emplace_back( senders, mutex_, "AIMD", aimd_.get()[ i ] );
+        sender_controls.emplace_back( aimd_senders, mutex_, "AIMD" + to_string(i + 1), aimd_.get()[ i ] );
       }
 
+      HBox remy_senders;
+      stack.pack_start( remy_senders, PACK_SHRINK );
       for ( unsigned int i = 0; i < num_senders; i++ ) {
-	sender_controls.emplace_back( senders, mutex_, "RemyCC", remy_.get()[ i ] );
+        sender_controls.emplace_back( remy_senders, mutex_, "RemyCC" + to_string(i + 1), remy_.get()[ i ] );
       }
 
       /* numerical sliders */
@@ -88,6 +90,7 @@ GTKFader::GTKFader( const unsigned int & num_senders )
       stack.pack_start( numeric );
 
       LabeledScale link_rate( numeric, "<b>Link rate</b> (Mbps)", 0.3, 300.1, 0.1, 10, link_rate_ );
+      LabeledScale rtt( numeric, "<b>RTT</b> (ms)", 5, 500, 5, 1, rtt_ );
       LabeledScale buffer( numeric, "<b>Buffer cap</b> (pkts)", 0, 20000, 1, 1, buffer_size_ );
       LabeledScale speed( numeric, "<b>Speed</b> (%)", 0, 5000, 1, 60 * 100, time_increment_ );
       LabeledScale width( numeric, "<b>Width</b> (s)", 1, 100, 0.1, 1, horizontal_size_ );

--- a/graph/fader.hh
+++ b/graph/fader.hh
@@ -8,6 +8,7 @@
 class GTKFader
 {
   std::atomic<double> link_rate_ { 1 };
+  std::atomic<double> rtt_ { 150 };
   std::atomic<double> time_increment_ { 0.65 / 60.0 }; /* a little slower than real time by default */
   std::atomic<double> horizontal_size_ { 10 };
   std::atomic<double> buffer_size_ { 1000 };
@@ -27,6 +28,7 @@ public:
   void update( NetworkType & network );
 
   double link_rate( void ) const { return link_rate_; }
+  double rtt( void ) const { return rtt_; }
   double time_increment( void ) const { return time_increment_; }
   double horizontal_size( void ) const { return horizontal_size_; }
   double buffer_size( void ) const { return buffer_size_; }

--- a/src/memoryrange.hh
+++ b/src/memoryrange.hh
@@ -16,6 +16,9 @@ class MemoryRange {
 private:
   Memory _lower, _upper;  
 
+  /* _active_axis specifies the group of signals in Memory used by the sender. 
+     For example, Fish only uses signal rtt_diff, while Rat uses four signals: 
+     rec_send_ewma, rec_rec_ewma, rtt_ratio and slow_rec_rec_rewma. */
   std::vector< Axis > _active_axis;
 
   mutable std::vector< boost::accumulators::accumulator_set< Memory::DataType,

--- a/src/network.hh
+++ b/src/network.hh
@@ -97,6 +97,8 @@ public:
   const double & tickno( void ) const { return _tickno; }
 
   Link & mutable_link( void ) { return _link; }
+
+  Delay & mutable_delay( void ) { return _delay; }
 };
 
 #endif


### PR DESCRIPTION
Added ability to change RTT, and used drop-down menu to control the number of active (AIMD, RemyCC) senders in Ratatouille. The new control panel now looks like the following:
![screenshot from 2016-03-10 23 51 12](https://cloud.githubusercontent.com/assets/3849492/13690835/98861164-e6e8-11e5-8637-1570a498ff7d.png)

@keithw Ratatouille sometimes produces the following exception when user decreases RTT:
> ratatouille: ./../src/delay.hh:30: void Delay::tick(NextHop&, const double&) [with NextHop = Receiver]: Assertion `std::get< 0 >( _queue.front() ) == tickno' failed. 


The current implementation is not designed to handle decreased RTT ( e.g. Delay._queue might no longer be in increasing tickno order). I'm not sure what's a nice way to handle this. Maybe we can simply reset senders in this case? 