### PR TITLE
Add ability for sender-logger to turn senders on at different times

### DIFF
--- a/scripts/datautils.py
+++ b/scripts/datautils.py
@@ -84,7 +84,7 @@ class RunData(object):
     }
 
     FUNCTION_ATTRIBUTES = {
-        "lambda_reciprocal": (lambda x: 1/x, "lambda")
+        "lambda_reciprocal": (lambda x: 1/x if x != 0 else None, "lambda")
     }
 
     def __init__(self, pb, start_time=0, end_time=None, actions=None):

--- a/scripts/list_plots.py
+++ b/scripts/list_plots.py
@@ -35,7 +35,12 @@ for entry in entries:
             print("{} - could not open args.json: {}".format(dirname, e))
         continue
 
-    jsondict = json.load(argsfile)
+    try:
+        jsondict = json.load(argsfile)
+    except ValueError as e:
+        if args.verbosity >= 1:
+            print("{} - could not parse args.json: {}".format(dirname, e))
+        continue
     argsfile.close()
     git_dict = jsondict.get("git", {})
     git_branch = git_dict.get("branch", "<unknown>")

--- a/scripts/plot_log.py
+++ b/scripts/plot_log.py
@@ -523,6 +523,8 @@ senderrunner_group.add_argument("-i", "--interval", type=float, default=0.1,
     help="Logging interval (seconds)")
 senderrunner_group.add_argument("-T", "--sim-time", type=float, default=100,
     help="Simulation time to run for (seconds)")
+senderrunner_group.add_argument("--sender1-on", type=float, default=None,
+    help="Time to turn sender 1 on (seconds)")
 senderrunner_group.add_argument("--sender", type=str, default="rat",
     help="Sender type (poisson or rat)", choices=('poisson', 'rat'))
 parser.add_argument("-O", "--plots-dir", type=str, default=None,
@@ -542,8 +544,8 @@ data = datautils.read_data_file(args.inputfile)
 
 # If there's nothing in it, it was probably a RemyCC
 if not data.run_data:
-    parameter_keys = ["nsenders", "link_ppt", "delay", "buffer_size", "interval", "sim_time", "sender"]
-    parameters = {key: getattr(args, key) for key in parameter_keys}
+    parameter_keys = ["nsenders", "link_ppt", "delay", "buffer_size", "interval", "sim_time", "sender", "sender1_on"]
+    parameters = {key: getattr(args, key) for key in parameter_keys if getattr(args, key) is not None}
     datafile = args.inputfile + ".data"
     parameters["datafile"] = datafile
     outfile = args.inputfile + ".out"
@@ -612,6 +614,12 @@ if not args.animations_only:
             TwoScalesTimePlotGenerator(("rtt_diff", 0), ("packets_in_flight", 0)),
             TwoScalesTimePlotGenerator(("lambda_reciprocal", 0), ("rtt_diff", 0)),
             SingleSenderParametricPlotGenerator(("lambda_reciprocal", "rtt_diff"), 0),
+            TimePlotGenerator("actual_intersend", "lambda_reciprocal", senders=1, plot_kwargs=[{'linestyle': 'None', 'marker': 'x'}, {}]),
+            TwoScalesTimePlotGenerator(("rtt_diff", 1), ("lambda", 1)),
+            TwoScalesTimePlotGenerator(("rtt_diff", 1), ("lambda_reciprocal", 1)),
+            TwoScalesTimePlotGenerator(("rtt_diff", 1), ("packets_in_flight", 1)),
+            TwoScalesTimePlotGenerator(("lambda_reciprocal", 1), ("rtt_diff", 1)),
+            SingleSenderParametricPlotGenerator(("lambda_reciprocal", "rtt_diff"), 1),
         ])
 
     elif args.sender == "rat":

--- a/scripts/remy_tool_runner.py
+++ b/scripts/remy_tool_runner.py
@@ -12,7 +12,7 @@ class BaseRemyToolRunner(object):
         self.command = kwargs.pop('command', self.COMMAND)
 
         self.default_parameters = dict(self.general_default_parameters)
-        for key in self.default_parameters:
+        for _, key in self.program_parameters:
             if key in kwargs:
                 self.default_parameters[key] = kwargs.pop(key)
 
@@ -22,7 +22,8 @@ class BaseRemyToolRunner(object):
     def _get_parameters(self, parameters, quiet=False):
         """Returns a dict of parameters, including default parameters.
         Warns if any parameters were unrecognized."""
-        unrecognized = [k for k in parameters if k not in self.default_parameters]
+        recognized = [p[1] for p in self.program_parameters]
+        unrecognized = [k for k in parameters if k not in recognized]
         if unrecognized and not quiet:
             warn("Unrecognized parameters: {}".format(unrecognized))
         result = dict(self.default_parameters)
@@ -66,7 +67,7 @@ class BaseRemyToolRunner(object):
         parameters = self._get_parameters(parameters)
         command = [self.command, "if={:s}".format(remyccfilename)]
         command += ["{}={}".format(rroptname, parameters[paramname]) for rroptname, paramname in
-                self.program_parameters]
+                self.program_parameters if paramname in parameters]
         output = subprocess.check_output(command, stderr=subprocess.STDOUT)
         output = output.decode()
         self._write_to_file(command, output, outfile)
@@ -76,7 +77,6 @@ class BaseRemyToolRunner(object):
 class SenderRunnerRunner(BaseRemyToolRunner):
 
     general_default_parameters = {
-        'sender': '',
         'nsenders': 2,
         'link_ppt': 1.0,
         'delay': 150.0,
@@ -103,14 +103,12 @@ class SenderRunnerRunner(BaseRemyToolRunner):
 class SenderLoggerRunner(BaseRemyToolRunner):
 
     general_default_parameters = {
-        'sender': '',
         'nsenders': 2,
         'link_ppt': 1.0,
         'delay': 150.0,
         'buffer_size': 'inf',
         'interval': 1.0,
         'sim_time': 1000.0,
-        'datafile': '',
     }
 
     program_parameters = [
@@ -123,6 +121,7 @@ class SenderLoggerRunner(BaseRemyToolRunner):
         ("interval", "interval"),
         ("time", "sim_time"),
         ("of", "datafile"),
+        ("sender1on", "sender1_on"),
     ]
 
     COMMAND = os.path.join(ROOTDIR, "src", "sender-logger")

--- a/src/network.cc
+++ b/src/network.cc
@@ -87,23 +87,31 @@ void Network<Gang1Type, Gang2Type>::run_simulation_until( const double tick_limi
 }
 
 template <class Gang1Type, class Gang2Type>
-void Network<Gang1Type, Gang2Type>::run_simulation_with_logging( const double & duration,
-                                                                 SimulationRunData & run_data,
-                                                                 const double interval )
+void Network<Gang1Type, Gang2Type>::run_simulation_with_logging_until( const double tick_limit,
+                                                                       SimulationRunData & run_data,
+                                                                       const double interval )
 {
-  assert( _tickno == 0 );
+  if ( _tickno >= tick_limit ) {
+    return;
+  }
+
   double next_log_time = interval;
 
-  while ( _tickno < duration ) {
+  while ( true ) {
     /* find element with soonest event */
-    _tickno = min( min( _senders.next_event_time( _tickno ),
+    double next_tickno = min( min( _senders.next_event_time( _tickno ),
       _link.next_event_time( _tickno ) ),
        min( _delay.next_event_time( _tickno ),
       _rec.next_event_time( _tickno ) ) );
 
-    if ( _tickno > duration ) break;
-    assert( _tickno < std::numeric_limits<double>::max() );
+    if ( next_tickno > tick_limit ) {
+      _tickno = tick_limit;
+      break;
+    }
 
+    assert( next_tickno < std::numeric_limits<double>::max() );
+
+    _tickno = next_tickno;
     tick();
 
     if ( _tickno > next_log_time ) {

--- a/src/network.hh
+++ b/src/network.hh
@@ -38,7 +38,7 @@ public:
       delay( dna.delay() ),
       buffer_size( dna.buffer_size() )
   {}
-  
+
   NetConfig & set_link_ppt( const double s_link_ppt ) { link_ppt = s_link_ppt; return *this; }
   NetConfig & set_delay( const double s_delay ) { delay = s_delay; return *this; }
   NetConfig & set_num_senders( const unsigned int n ) { num_senders = n; return *this; }
@@ -88,7 +88,7 @@ public:
 
   void run_simulation( const double & duration );
 
-  void run_simulation_with_logging( const double & duration, SimulationRunData &, const double interval );
+  void run_simulation_with_logging_until( const double tick_limit, SimulationRunData &, const double interval );
 
   void run_simulation_until( const double tick_limit );
 


### PR DESCRIPTION
Adds the ability to turn on senders 0 and 1 at different times when running `sender-logger`, through a new `sender1on=` option.

This involves (among other things) changing `Network::run_simulation_with_logging` to `Network::run_simulation_with_logging_until`, mirroring `Network::run_simulation_until`.

The log-plotting script has also been modified to allow for this functionality, and generate plots that previously weren't relevant (because sender 1 wasn't doing anything) but now are.