### PR TITLE
Added in stochastic loss parameter and object, with new stochastic lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Basic usage:
   sender "on" for an exponentially-distributed amount of time (mean 5
   s) and off for durations drawn from the same distribution.
 
+* Use the `cf=` argument to pass in a specific configuration file into Remy.
+  To create this configuration protobuf, run `./configuration`, with the 
+  desired specifications about the range of networks to train over. The 
+  configuration executable takes in information about link speed, minRTT, 
+  on and off times, number of senders, buffer size, utility function loss 
+  penalty and stochastic loss rate.
+
 * Use the of= argument to have Remy save its RemyCCs to disk. It will
   save every step of the iteration.
 

--- a/protobufs/dna.proto
+++ b/protobufs/dna.proto
@@ -99,7 +99,9 @@ message ConfigRange {
   optional Range buffer_size = 74;
   optional Range mean_off_duration = 75;
   optional Range mean_on_duration = 76;
-  optional uint32 simulation_ticks = 77;
+  optional double utility_penalty = 77;
+  optional double stochastic_loss_rate = 78;
+  optional uint32 simulation_ticks = 79;
 }
 
 message NetConfig {
@@ -109,6 +111,8 @@ message NetConfig {
   optional double link_ppt = 4;
   optional double delay = 5;
   optional uint32 buffer_size = 6;
+  optional double utility_penalty = 7;
+  optional double stochastic_loss_rate = 8;
 }
 
 message ConfigVector {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,9 +9,9 @@ common_source = delay.hh evaluator.cc evaluator.hh                 \
 	memory.cc memory.hh memoryrange.cc memoryrange.hh              \
 	network.cc network.hh packet.hh poisson.hh                     \
 	random.cc random.hh rat.cc rat.hh rat-templates.cc             \
-	receiver.cc receiver.hh sendergang.cc sendergang.hh            \
-	senderdatapoint.hh                                             \
-	sendergangofgangs.cc sendergangofgangs.hh                  \
+	receiver.cc receiver.hh stochastic-loss.hh                     \
+	sendergang.cc sendergang.hh senderdatapoint.hh                 \
+	sendergangofgangs.cc sendergangofgangs.hh                      \
 	utility.hh whisker.cc whisker.hh whiskertree.cc whiskertree.hh \
 	aimd-templates.cc aimd.cc aimd.hh                              \
 	configrange.hh configrange.cc                              \

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -18,6 +18,8 @@ ConfigRange::ConfigRange( void ) :
   mean_off_duration( Range() ),
   num_senders( Range() ),
   buffer_size( Range() ),
+  utility_penalty( 0 ),
+  stochastic_loss_rate( 0 ),
   simulation_ticks( 1000000 )
 {
 }
@@ -29,6 +31,8 @@ ConfigRange::ConfigRange( RemyBuffers::ConfigRange input_config ) :
   mean_off_duration( Range( input_config.mean_off_duration() ) ),
   num_senders( Range( input_config.num_senders() ) ),
   buffer_size( Range( input_config.buffer_size() ) ),
+  utility_penalty( input_config.utility_penalty() ),
+  stochastic_loss_rate( input_config.stochastic_loss_rate() ),
   simulation_ticks( input_config.simulation_ticks() )
 {
 }
@@ -42,6 +46,8 @@ RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
   ret.mutable_mean_on_duration()->CopyFrom( pair_to_range( mean_on_duration ) );
   ret.mutable_mean_off_duration()->CopyFrom( pair_to_range( mean_off_duration ) );
   ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );
+  ret.set_utility_penalty( utility_penalty );
+  ret.set_stochastic_loss_rate( stochastic_loss_rate );
   ret.set_simulation_ticks( simulation_ticks );
 
   return ret;

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -42,6 +42,8 @@ public:
   Range mean_off_duration;
   Range num_senders;
   Range buffer_size;
+  double utility_penalty;
+  double stochastic_loss_rate;
   unsigned int simulation_ticks;
 
   ConfigRange( void );

--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -19,7 +19,7 @@ Evaluator< T >::Evaluator( const ConfigRange & range )
         for (double on = range.mean_on_duration.low; on <= range.mean_on_duration.high; on += range.mean_on_duration.incr) {
           for (double off = range.mean_off_duration.low; off <= range.mean_off_duration.high; off += range.mean_off_duration.incr) {
             for ( double buffer_size = range.buffer_size.low; buffer_size <= range.buffer_size.high; buffer_size += range.buffer_size.incr) {
-              _configs.push_back( NetConfig().set_link_ppt( link_ppt ).set_delay( rtt ).set_num_senders( senders ).set_on_duration( on ).set_off_duration(off).set_buffer_size( buffer_size ) );
+              _configs.push_back( NetConfig().set_link_ppt( link_ppt ).set_delay( rtt ).set_num_senders( senders ).set_on_duration( on ).set_off_duration(off).set_buffer_size( buffer_size ).set_utility_penalty( range.utility_penalty ).set_stochastic_loss_rate( range.stochastic_loss_rate ) );
               if ( range.buffer_size.isOne() ) { break; }
             }
             if ( range.mean_off_duration.isOne() ) { break; }

--- a/src/network.cc
+++ b/src/network.cc
@@ -9,8 +9,8 @@ Network<Gang1Type, Gang2Type>::Network( const typename Gang1Type::Sender & examp
 					PRNG & s_prng,
 					const NetConfig & config )
   : _prng( s_prng ),
-    _senders( Gang1Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, example_sender1, _prng ),
-	      Gang2Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, example_sender2, _prng, config.num_senders ) ),
+    _senders( Gang1Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, config.stochastic_loss_rate, config.utility_penalty, example_sender1, _prng ),
+	      Gang2Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, config.stochastic_loss_rate, config.utility_penalty, example_sender2, _prng, config.num_senders ) ),
     _link( config.link_ppt, config.buffer_size ),
     _delay( config.delay ),
     _rec(),
@@ -23,7 +23,7 @@ Network<Gang1Type, Gang2Type>::Network( const typename Gang1Type::Sender & examp
 					PRNG & s_prng,
 					const NetConfig & config )
   : _prng( s_prng ),
-    _senders( Gang1Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, example_sender1, _prng ),
+    _senders( Gang1Type( config.mean_on_duration, config.mean_off_duration, config.num_senders, config.stochastic_loss_rate, config.utility_penalty, example_sender1, _prng ),
 	      Gang2Type() ),
     _link( config.link_ppt, config.buffer_size ),
     _delay( config.delay ),

--- a/src/network.hh
+++ b/src/network.hh
@@ -20,6 +20,8 @@ public:
   double link_ppt;
   double delay;
   double buffer_size;
+  double utility_penalty;
+  double stochastic_loss_rate;
 
   NetConfig( void )
     : mean_on_duration( 5000.0 ),
@@ -27,7 +29,9 @@ public:
       num_senders( 8 ),
       link_ppt( 1.0 ),
       delay( 150 ),
-      buffer_size( std::numeric_limits<unsigned int>::max() )
+      buffer_size( std::numeric_limits<unsigned int>::max() ),
+      utility_penalty( 0 ),
+      stochastic_loss_rate( 0 )
   {}
 
   NetConfig( const RemyBuffers::NetConfig & dna )
@@ -36,7 +40,9 @@ public:
       num_senders( dna.num_senders() ),
       link_ppt( dna.link_ppt() ),
       delay( dna.delay() ),
-      buffer_size( dna.buffer_size() )
+      buffer_size( dna.buffer_size() ),
+      utility_penalty( dna.utility_penalty() ),
+      stochastic_loss_rate( dna.stochastic_loss_rate() )
   {}
 
   NetConfig & set_link_ppt( const double s_link_ppt ) { link_ppt = s_link_ppt; return *this; }
@@ -45,6 +51,8 @@ public:
   NetConfig & set_on_duration( const double & duration ) { mean_on_duration = duration; return *this; }
   NetConfig & set_off_duration( const double & duration ) { mean_off_duration = duration; return *this; }
   NetConfig & set_buffer_size( const unsigned int n ) { buffer_size = n; return *this; }
+  NetConfig & set_utility_penalty( const double penalty ) { utility_penalty = penalty; return *this; }
+  NetConfig & set_stochastic_loss_rate ( const double rate ) { stochastic_loss_rate = rate; return *this; }
 
   RemyBuffers::NetConfig DNA( void ) const
   {
@@ -55,14 +63,16 @@ public:
       ret.set_delay( delay );
       ret.set_link_ppt( link_ppt );
       ret.set_buffer_size( buffer_size );
+      ret.set_utility_penalty( utility_penalty );
+      ret.set_stochastic_loss_rate( stochastic_loss_rate );
       return ret;
   }
 
   std::string str( void ) const
   {
     char tmp[ 256 ];
-    snprintf( tmp, 256, "mean_on=%f, mean_off=%f, nsrc=%f, link_ppt=%f, delay=%f, buffer_size=%f\n",
-	     mean_on_duration, mean_off_duration, num_senders, link_ppt, delay, buffer_size );
+    snprintf( tmp, 256, "mean_on=%f, mean_off=%f, nsrc=%f, link_ppt=%f, delay=%f, buffer_size=%f, utility_penalty=%f, stochastic_loss_rate=%f\n",
+	    mean_on_duration, mean_off_duration, num_senders, link_ppt, delay, buffer_size, utility_penalty, stochastic_loss_rate );
     return tmp;
   }
 };

--- a/src/remy-poisson.cc
+++ b/src/remy-poisson.cc
@@ -77,6 +77,10 @@ int main( int argc, char *argv[] )
   printf( "#######################\n" );
   printf( "Evaluator simulations will run for %d ticks\n",
     options.config_range.simulation_ticks );
+  printf( "Using %f as the delay penalty\n",
+    options.config_range.utility_penalty );
+  printf( "Using %f as the stochastic loss rate \n",
+    options.config_range.stochastic_loss_rate );
   printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
 	  options.config_range.link_ppt.low,
 	  options.config_range.link_ppt.high );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -101,6 +101,10 @@ int main( int argc, char *argv[] )
   printf( "#######################\n" );
   printf( "Evaluator simulations will run for %d ticks\n",
     options.config_range.simulation_ticks );
+  printf( "Using %f as the delay penalty\n",
+    options.config_range.utility_penalty );
+  printf( "Using %f as the stochastic loss rate \n",
+    options.config_range.stochastic_loss_rate );
   printf( "Optimizing window increment: %d, window multiple: %d, intersend: %d\n",
           whisker_options.optimize_window_increment, whisker_options.optimize_window_multiple,
           whisker_options.optimize_intersend);

--- a/src/scoring-example.cc
+++ b/src/scoring-example.cc
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <iostream>
+#include <limits>
 
 #include "evaluator.hh"
 #include "configrange.hh"
@@ -20,6 +21,10 @@ int main( int argc, char *argv[] )
   double delay = 100.0;
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
+  bool inf_buffers = true;
+  double buffer_size = numeric_limits<unsigned int>::max();
+  double utility_penalty = 0;
+  double stochastic_loss_rate = 0;
 
   for ( int i = 1; i < argc; i++ ) {
     string arg( argv[ i ] );
@@ -65,7 +70,21 @@ int main( int argc, char *argv[] )
     } else if ( arg.substr( 0, 4 ) == "off=" ) {
       mean_off_duration = atof( arg.substr( 4 ).c_str() );
       fprintf( stderr, "Setting mean_off_duration to %f ms\n", mean_off_duration );
+    } else if ( arg.substr( 0, 4 ) == "buf=" ) {
+      buffer_size = atof( arg.substr( 4 ).c_str() );
+      fprintf( stderr, "Setting buf_size to %f ms\n", buffer_size );
+      inf_buffers = false;
+    } else if ( arg.substr( 0, 8 ) == "penalty=" ) {
+      utility_penalty = atof( arg.substr( 8 ).c_str() );
+      fprintf( stderr, "Setting utility penalty to %f \n", utility_penalty );
+    } else if ( arg.substr( 0, 7 ) == "s_loss=" ) {
+      stochastic_loss_rate = atof( arg.substr( 7 ).c_str() );
+      fprintf( stderr, "Setting stochastic loss rate to %f \n", stochastic_loss_rate );
     }
+  }
+
+  if ( inf_buffers ) {
+    fprintf( stderr, "Setting buffer size to be infinite\n" );
   }
 
   ConfigRange configuration_range;
@@ -74,6 +93,9 @@ int main( int argc, char *argv[] )
   configuration_range.num_senders = Range(num_senders, num_senders, 0 );
   configuration_range.mean_on_duration = Range(mean_on_duration, mean_on_duration, 0);
   configuration_range.mean_off_duration = Range(mean_off_duration, mean_off_duration, 0);
+  configuration_range.buffer_size = Range(buffer_size, buffer_size, 0 );
+  configuration_range.utility_penalty = utility_penalty;
+  configuration_range.stochastic_loss_rate = stochastic_loss_rate;
 
   Evaluator< WhiskerTree > eval( configuration_range );
 

--- a/src/sender-runner.cc
+++ b/src/sender-runner.cc
@@ -53,6 +53,8 @@ int main( int argc, char *argv[] )
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
   double buffer_size = numeric_limits<unsigned int>::max();
+  double utility_penalty = 0;
+  double stochastic_loss_rate = 0;
   unsigned int simulation_ticks = 1000000;
 
   for ( int i = 1; i < argc && !is_poisson; i++ ) {
@@ -118,6 +120,12 @@ int main( int argc, char *argv[] )
       } else {
         buffer_size = atoi( arg.substr( 4 ).c_str() );
       }
+    } else if ( arg.substr( 0, 8 ) == "penalty=" ) {
+      utility_penalty = atof( arg.substr( 8 ).c_str() );
+      fprintf( stderr, "Setting utility penalty to %f \n", utility_penalty );
+    } else if ( arg.substr( 0, 7 ) == "s_loss=" ) {
+      stochastic_loss_rate = atof( arg.substr( 7 ).c_str() );
+      fprintf( stderr, "Setting stochastic loss rate to %f \n", stochastic_loss_rate );
     }
   }
 
@@ -128,6 +136,8 @@ int main( int argc, char *argv[] )
   configuration_range.mean_on_duration = Range( mean_on_duration, mean_on_duration, 0 );
   configuration_range.mean_off_duration = Range( mean_off_duration, mean_off_duration, 0 );
   configuration_range.buffer_size = Range( buffer_size, buffer_size, 0 );
+  configuration_range.utility_penalty = utility_penalty;
+  configuration_range.stochastic_loss_rate = stochastic_loss_rate;
   configuration_range.simulation_ticks = simulation_ticks;
 
   if ( is_poisson ) {

--- a/src/sendergang.cc
+++ b/src/sendergang.cc
@@ -8,6 +8,8 @@ template <class SenderType, class SwitcherType>
 SenderGang<SenderType, SwitcherType>::SenderGang( const double mean_on_duration,
 						  const double mean_off_duration,
 						  const unsigned int num_senders,
+                                                  const double stochastic_loss_rate,
+                                                  const double delay_penalty,
 						  const SenderType & exemplar,
 						  PRNG & prng,
 						  const unsigned int id_range_begin )
@@ -20,6 +22,10 @@ SenderGang<SenderType, SwitcherType>::SenderGang( const double mean_on_duration,
     _gang.emplace_back( i + id_range_begin,
 			_start_distribution.sample( _prng ),
 			exemplar );
+  }
+  for ( auto &x : _gang ) {
+    x.utility.set_delay_penalty( delay_penalty );
+    x.stochastic_link.set_rate( stochastic_loss_rate );
   }
 }
 
@@ -168,9 +174,12 @@ void SwitchedSender<SenderType>::receive_feedback( Receiver & rec )
 {
   if ( rec.readable( id ) ) {
     const std::vector< Packet > & packets = rec.packets_for( id );
-
-    utility.packets_received( packets );
-    sender.packets_received( packets );
+    std::vector< Packet > new_packets;
+    new_packets = stochastic_link.drop_packets(packets, global_PRNG() );
+    if ( !(new_packets.empty()) ) {
+      utility.packets_received( new_packets );
+      sender.packets_received( new_packets );
+    }
 
     rec.clear( id );
   }

--- a/src/sendergang.hh
+++ b/src/sendergang.hh
@@ -7,6 +7,7 @@
 #include "receiver.hh"
 #include "utility.hh"
 #include "senderdatapoint.hh"
+#include "stochastic-loss.hh"
 
 template <class SenderType>
 class SwitchedSender {
@@ -35,6 +36,7 @@ public:
   double next_event_time( const double & tickno ) const;
   SenderDataPoint statistics_for_log( void ) const;
   Utility utility;
+  StochasticLoss stochastic_link;
   bool sending;
   unsigned int id;
 
@@ -45,6 +47,7 @@ public:
       next_switch_tick( start_tick ),
       sender( s_sender ),
       utility(),
+      stochastic_link(StochasticLoss( 0 ) ),
       sending( false ),
       id( s_id )
   {}
@@ -131,6 +134,8 @@ public:
   SenderGang( const double mean_on_duration,
 	      const double mean_off_duration,
 	      const unsigned int num_senders,
+              const double stochastic_loss_rate,
+              const double delay_penalty,
 	      const SenderType & exemplar,
 	      PRNG & s_prng,
 	      const unsigned int id_range_begin = 0 );

--- a/src/stochastic-loss.hh
+++ b/src/stochastic-loss.hh
@@ -1,0 +1,32 @@
+#ifndef STOCHASTIC_LOSS
+#define STOCHASTIC_LOSS
+#include <random>
+#include <vector>
+#include "exponential.hh"
+#include "packet.hh"
+
+class StochasticLoss 
+{
+  private:
+   std::bernoulli_distribution _distr;
+  public:
+    StochasticLoss( const double & rate ): _distr() { _distr = std::bernoulli_distribution( rate ); }
+
+    void set_rate( const double & rate ) 
+    {
+      _distr = std::bernoulli_distribution( rate );
+    }
+
+    std::vector< Packet > drop_packets( std::vector< Packet > packets, PRNG & prng ) 
+    {
+      std::vector< Packet > new_packets;
+      new_packets = std::vector< Packet >();
+      for (const auto &x: packets) {
+        if (!( _distr ( prng ) )) {
+          new_packets.push_back(x);
+        }
+      }
+      return new_packets;
+    }  
+};
+#endif


### PR DESCRIPTION
-Added a new object that simulates stochastic packet loss, dropping packets randomly in the receiver (just has a bernoulli distribution)
-Added an input parameter to set the rate at which packets are dropped (the probability of the bernoulli distribution)
-Added another input parameter to add a delay penalty in the utility calculation, when a packet loss is seen, of the form:
- utility = avg_throughput - delta*log(avg_delay)
- To calculate the average delay: if a loss is seen, add k* last_RTT* (# lost packets)
- k = 0 represents no delay penalty

I had to change a couple of object constructors to make this work, and I modified:

- the readme file (to say some instructions about creating an input protobuf)
- sendergang.cc, sendergang.hh, utility.hh
- evaluator.cc, network.cc, network.hh, configrange.cc, configrange.hh
- remy.cc, remy-poisson.cc, input-configrange.cc, scoring-example.cc, sender-runner.cc
- protobufs/dna.proto
