### PR TITLE
Adding stochastic loss network element that randomly drops packets

### DIFF
--- a/protobufs/dna.proto
+++ b/protobufs/dna.proto
@@ -100,6 +100,7 @@ message ConfigRange {
   optional Range mean_off_duration = 75;
   optional Range mean_on_duration = 76;
   optional uint32 simulation_ticks = 77;
+  optional Range stochastic_loss_rate = 78;
 }
 
 message NetConfig {
@@ -109,6 +110,7 @@ message NetConfig {
   optional double link_ppt = 4;
   optional double delay = 5;
   optional uint32 buffer_size = 6;
+  optional double stochastic_loss_rate = 7;
 }
 
 message ConfigVector {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ LDADD = ../protobufs/libremyprotos.a -lm $(protobuf_LIBS)
 bin_PROGRAMS = remy remy-poisson sender-runner sender-logger scoring-example configuration inspect-config inspect-simulationsdata
 
 common_source = delay.hh evaluator.cc evaluator.hh                 \
-	exponential.hh link.hh link-templates.cc                       \
+	exponential.hh link.hh link-templates.cc stochastic-loss.hh                      \
 	memory.cc memory.hh memoryrange.cc memoryrange.hh              \
 	network.cc network.hh packet.hh poisson.hh                     \
 	random.cc random.hh rat.cc rat.hh rat-templates.cc             \

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -18,7 +18,8 @@ ConfigRange::ConfigRange( void ) :
   mean_off_duration( Range() ),
   num_senders( Range() ),
   buffer_size( Range() ),
-  simulation_ticks( 1000000 )
+  simulation_ticks( 1000000 ),
+  stochastic_loss_rate( Range().set_low(0).set_high(0).set_incr(0) )
 {
 }
 
@@ -29,7 +30,8 @@ ConfigRange::ConfigRange( RemyBuffers::ConfigRange input_config ) :
   mean_off_duration( Range( input_config.mean_off_duration() ) ),
   num_senders( Range( input_config.num_senders() ) ),
   buffer_size( Range( input_config.buffer_size() ) ),
-  simulation_ticks( input_config.simulation_ticks() )
+  simulation_ticks( input_config.simulation_ticks() ),
+  stochastic_loss_rate( Range( input_config.stochastic_loss_rate() ) )
 {
 }
 
@@ -43,6 +45,6 @@ RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
   ret.mutable_mean_off_duration()->CopyFrom( pair_to_range( mean_off_duration ) );
   ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );
   ret.set_simulation_ticks( simulation_ticks );
-
+  ret.mutable_stochastic_loss_rate()->CopyFrom( pair_to_range( stochastic_loss_rate ) );
   return ret;
 }

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -43,6 +43,7 @@ public:
   Range num_senders;
   Range buffer_size;
   unsigned int simulation_ticks;
+  Range stochastic_loss_rate;
 
   ConfigRange( void );
   ConfigRange( RemyBuffers::ConfigRange configrange );

--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -19,7 +19,10 @@ Evaluator< T >::Evaluator( const ConfigRange & range )
         for (double on = range.mean_on_duration.low; on <= range.mean_on_duration.high; on += range.mean_on_duration.incr) {
           for (double off = range.mean_off_duration.low; off <= range.mean_off_duration.high; off += range.mean_off_duration.incr) {
             for ( double buffer_size = range.buffer_size.low; buffer_size <= range.buffer_size.high; buffer_size += range.buffer_size.incr) {
-              _configs.push_back( NetConfig().set_link_ppt( link_ppt ).set_delay( rtt ).set_num_senders( senders ).set_on_duration( on ).set_off_duration(off).set_buffer_size( buffer_size ) );
+              for ( double loss_rate = range.stochastic_loss_rate.low; loss_rate <= range.stochastic_loss_rate.high; loss_rate += range.stochastic_loss_rate.incr) {
+                _configs.push_back( NetConfig().set_link_ppt( link_ppt ).set_delay( rtt ).set_num_senders( senders ).set_on_duration( on ).set_off_duration(off).set_buffer_size( buffer_size ).set_stochastic_loss_rate( loss_rate ) );
+                if ( range.stochastic_loss_rate.isOne() ) { break; }
+              }
               if ( range.buffer_size.isOne() ) { break; }
             }
             if ( range.mean_off_duration.isOne() ) { break; }

--- a/src/input-configrange.cc
+++ b/src/input-configrange.cc
@@ -112,6 +112,37 @@ bool update_config_with_uint32(RemyBuffers::ConfigRange & range,
   return false;
 }
 
+bool update_config_with_double(RemyBuffers::ConfigRange & range,
+    void (RemyBuffers::ConfigRange::*set_fn)(double), int argc, char *argv[],
+    string arg_name, bool mandatory) {
+  bool found = false;
+  double value = -1;
+  int arg_name_size = arg_name.size();
+  for ( int i = 1; i < argc; i++ ) {
+    string arg( argv[i] );
+    if ( arg.substr( 0, arg_name_size+1 ) == arg_name + "=" ) {
+      found = true;
+      try {
+        value = atof( arg.substr( arg_name_size + 1 ).c_str() );
+      } catch ( invalid_argument ) {
+        fprintf( stderr, "Could not parse %s argument: %s\n", arg_name.c_str(), arg.c_str() );
+        exit(1);
+      }
+      break;
+    }
+  }
+  if ( !found && mandatory ) {
+    fprintf( stderr, "Please provide an argument for %s\n", arg_name.c_str() );
+    exit(1);
+  }
+  if ( found ) {
+    fprintf( stderr, "Setting %s to %f\n", arg_name.c_str(), value );
+    (range.*set_fn)(value);
+    return true;
+  }
+  fprintf( stderr, "No argument found for %s\n", arg_name.c_str() );
+  return false;
+}
 
 int main(int argc, char *argv[]) {
   string input_filename, output_filename;
@@ -159,9 +190,8 @@ int main(int argc, char *argv[]) {
   update_config_with_range(input_config.mutable_num_senders(), argc, argv, "nsrc", mandatory);
   update_config_with_range(input_config.mutable_mean_on_duration(), argc, argv, "on", mandatory);
   update_config_with_range(input_config.mutable_mean_off_duration(), argc, argv, "off", mandatory);
-
+  update_config_with_range(input_config.mutable_stochastic_loss_rate(), argc, argv, "sloss", mandatory);
   update_config_with_uint32(input_config, &RemyBuffers::ConfigRange::set_simulation_ticks, argc, argv, "ticks", mandatory);
-
   if ( !(infinite_buffers) ) {
     update_config_with_range(input_config.mutable_buffer_size(), argc, argv, "buf_size", mandatory);
   } else {
@@ -172,7 +202,6 @@ int main(int argc, char *argv[]) {
     input_config.mutable_buffer_size()->CopyFrom(buffer_size);
   }
 
-   
 
   // write to file
   char of[ 128 ];
@@ -182,7 +211,7 @@ int main(int argc, char *argv[]) {
     perror( "open" );
     exit( 1 );
   }
-  
+
 
   if ( not input_config.SerializeToFileDescriptor( fd ) ) {
     fprintf( stderr, "Could not serialize InputConfig parameters.\n" );

--- a/src/network.cc
+++ b/src/network.cc
@@ -15,7 +15,7 @@ Network<Gang1Type, Gang2Type>::Network( const typename Gang1Type::Sender & examp
     _delay( config.delay ),
     _rec(),
     _tickno( 0 ),
-    _stochastic_loss( 0 , _prng)
+    _stochastic_loss( config.stochastic_loss_rate , _prng)
 {
 }
 
@@ -30,7 +30,7 @@ Network<Gang1Type, Gang2Type>::Network( const typename Gang1Type::Sender & examp
     _delay( config.delay ),
     _rec(),
     _tickno( 0 ),
-    _stochastic_loss( 0 , _prng)
+    _stochastic_loss( config.stochastic_loss_rate , _prng)
 {
 }
 

--- a/src/network.hh
+++ b/src/network.hh
@@ -6,6 +6,7 @@
 #include "sendergangofgangs.hh"
 #include "link.hh"
 #include "delay.hh"
+#include "stochastic-loss.hh"
 #include "receiver.hh"
 #include "random.hh"
 #include "answer.pb.h"
@@ -78,7 +79,7 @@ private:
   Receiver _rec;
 
   double _tickno;
-
+  StochasticLoss _stochastic_loss;
   void tick( void );
 
 public:

--- a/src/network.hh
+++ b/src/network.hh
@@ -21,6 +21,7 @@ public:
   double link_ppt;
   double delay;
   double buffer_size;
+  double stochastic_loss_rate;
 
   NetConfig( void )
     : mean_on_duration( 5000.0 ),
@@ -28,7 +29,8 @@ public:
       num_senders( 8 ),
       link_ppt( 1.0 ),
       delay( 150 ),
-      buffer_size( std::numeric_limits<unsigned int>::max() )
+      buffer_size( std::numeric_limits<unsigned int>::max() ),
+      stochastic_loss_rate( 0 )
   {}
 
   NetConfig( const RemyBuffers::NetConfig & dna )
@@ -37,7 +39,8 @@ public:
       num_senders( dna.num_senders() ),
       link_ppt( dna.link_ppt() ),
       delay( dna.delay() ),
-      buffer_size( dna.buffer_size() )
+      buffer_size( dna.buffer_size() ),
+      stochastic_loss_rate( dna.stochastic_loss_rate() )
   {}
 
   NetConfig & set_link_ppt( const double s_link_ppt ) { link_ppt = s_link_ppt; return *this; }
@@ -46,6 +49,7 @@ public:
   NetConfig & set_on_duration( const double & duration ) { mean_on_duration = duration; return *this; }
   NetConfig & set_off_duration( const double & duration ) { mean_off_duration = duration; return *this; }
   NetConfig & set_buffer_size( const unsigned int n ) { buffer_size = n; return *this; }
+  NetConfig & set_stochastic_loss_rate( const double loss_rate ) { stochastic_loss_rate = loss_rate; return *this; }
 
   RemyBuffers::NetConfig DNA( void ) const
   {
@@ -56,14 +60,15 @@ public:
       ret.set_delay( delay );
       ret.set_link_ppt( link_ppt );
       ret.set_buffer_size( buffer_size );
+      ret.set_stochastic_loss_rate( stochastic_loss_rate );
       return ret;
   }
 
   std::string str( void ) const
   {
     char tmp[ 256 ];
-    snprintf( tmp, 256, "mean_on=%f, mean_off=%f, nsrc=%f, link_ppt=%f, delay=%f, buffer_size=%f\n",
-	     mean_on_duration, mean_off_duration, num_senders, link_ppt, delay, buffer_size );
+    snprintf( tmp, 256, "mean_on=%f, mean_off=%f, nsrc=%f, link_ppt=%f, delay=%f, buffer_size=%f, stochastic_loss_rate = %f\n",
+	     mean_on_duration, mean_off_duration, num_senders, link_ppt, delay, buffer_size, stochastic_loss_rate );
     return tmp;
   }
 };

--- a/src/remy-poisson.cc
+++ b/src/remy-poisson.cc
@@ -87,6 +87,7 @@ int main( int argc, char *argv[] )
 	  options.config_range.num_senders.low, options.config_range.num_senders.high );
   printf( "Optimizing for mean_on_duration in [%f, %f], mean_off_duration in [ %f, %f]\n",
 	  options.config_range.mean_on_duration.low, options.config_range.mean_on_duration.high, options.config_range.mean_off_duration.low, options.config_range.mean_off_duration.high );
+  printf( "Optimizing for stochastic_loss_rate in [%f, %f]\n", options.config_range.stochastic_loss_rate.low, options.config_range.stochastic_loss_rate.high );
   if ( options.config_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
     printf( "Optimizing for buffer_size in [%f, %f]\n",
             options.config_range.buffer_size.low,

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -109,7 +109,7 @@ int main( int argc, char *argv[] )
   print_range( options.config_range.num_senders, "num_senders" );
   print_range( options.config_range.mean_on_duration, "mean_on_duration" );
   print_range( options.config_range.mean_off_duration, "mean_off_duration" );
-
+  print_range( options.config_range.stochastic_loss_rate, "stochastic_loss_rate" );
   if ( options.config_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
     print_range( options.config_range.buffer_size, "buffer_size" );
   } else {

--- a/src/scoring-example.cc
+++ b/src/scoring-example.cc
@@ -20,7 +20,7 @@ int main( int argc, char *argv[] )
   double delay = 100.0;
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
-
+  double stochastic_loss_rate = 0;
   for ( int i = 1; i < argc; i++ ) {
     string arg( argv[ i ] );
     if ( arg.substr( 0, 3 ) == "if=" ) {
@@ -65,6 +65,9 @@ int main( int argc, char *argv[] )
     } else if ( arg.substr( 0, 4 ) == "off=" ) {
       mean_off_duration = atof( arg.substr( 4 ).c_str() );
       fprintf( stderr, "Setting mean_off_duration to %f ms\n", mean_off_duration );
+    } else if ( arg.substr(0, 6 ) == "sloss=" ) {
+      stochastic_loss_rate = atof( arg.substr( 6 ).c_str() );
+      fprintf( stderr, "Setting stochastic loss rate to %f\n", stochastic_loss_rate );
     }
   }
 
@@ -74,7 +77,7 @@ int main( int argc, char *argv[] )
   configuration_range.num_senders = Range(num_senders, num_senders, 0 );
   configuration_range.mean_on_duration = Range(mean_on_duration, mean_on_duration, 0);
   configuration_range.mean_off_duration = Range(mean_off_duration, mean_off_duration, 0);
-
+  configuration_range.stochastic_loss_rate = Range(stochastic_loss_rate, stochastic_loss_rate, 0);
   Evaluator< WhiskerTree > eval( configuration_range );
 
   // save problem to file

--- a/src/sender-runner.cc
+++ b/src/sender-runner.cc
@@ -53,6 +53,7 @@ int main( int argc, char *argv[] )
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
   double buffer_size = numeric_limits<unsigned int>::max();
+  double stochastic_loss_rate = 0;
   unsigned int simulation_ticks = 1000000;
 
   for ( int i = 1; i < argc && !is_poisson; i++ ) {
@@ -118,6 +119,9 @@ int main( int argc, char *argv[] )
       } else {
         buffer_size = atoi( arg.substr( 4 ).c_str() );
       }
+    } else if ( arg.substr( 0, 6 ) == "sloss=" ) {
+      stochastic_loss_rate = atof( arg.substr( 6 ).c_str() );
+      fprintf( stderr, "Setting stochastic loss rate to %f\n", stochastic_loss_rate );
     }
   }
 
@@ -128,6 +132,7 @@ int main( int argc, char *argv[] )
   configuration_range.mean_on_duration = Range( mean_on_duration, mean_on_duration, 0 );
   configuration_range.mean_off_duration = Range( mean_off_duration, mean_off_duration, 0 );
   configuration_range.buffer_size = Range( buffer_size, buffer_size, 0 );
+  configuration_range.stochastic_loss_rate = Range( stochastic_loss_rate, stochastic_loss_rate, 0);
   configuration_range.simulation_ticks = simulation_ticks;
 
   if ( is_poisson ) {

--- a/src/stochastic-loss.hh
+++ b/src/stochastic-loss.hh
@@ -1,0 +1,48 @@
+#ifndef STOCHASTICLOSS_HH
+#define STOCHASTICLOSS_HH
+
+#include "packet.hh"
+#include <deque>
+#include <tuple>
+#include <random>
+#include "exponential.hh"
+
+class StochasticLoss
+{
+  private:
+    std::deque< std::tuple< double, Packet > > _buffer;
+    double _loss_rate;
+    PRNG & _prng;
+    std::bernoulli_distribution _distr;
+
+  public:
+    StochasticLoss( const double & rate, PRNG &prng ) :  _buffer(), _loss_rate( rate ), _prng( prng ), _distr() { _distr = std::bernoulli_distribution( rate );}
+    template <class NextHop>
+    void tick( NextHop & next, const double & tickno )
+    {
+      // pops items off buffer and sends them to the next item
+      while ( (!_buffer.empty())) {
+        next.accept(std::get< 1 >(_buffer.front()), tickno);
+        _buffer.pop_front();
+      }
+    }
+    void accept( const Packet & p, const double & tickno ) noexcept
+    {
+      if (!(_distr( _prng ))) {
+        _buffer.emplace_back( tickno, p );
+      }
+    }
+
+
+    double next_event_time( const double & tickno ) const
+    {
+      if ( _buffer.empty() ) {
+        return std::numeric_limits<double>::max();
+      }
+      assert( std::get< 0 >( _buffer.front() ) >= tickno );
+      return std::get< 0 >( _buffer.front() );
+    }
+
+};
+
+#endif


### PR DESCRIPTION
-This element, similar to Delay, Link, and Receiver, has a:

- tick() function

- next_event_time() function

- accept() function

All it does is maintain a queue of packets to pass on to the next element, but uses a random seed to either drop or keep a packet before accepting the packet. I'm not 100 % sure that the next_event_time() function is completely accurate. The default loss_rate is set to 0,
so all the regression tests should pass.